### PR TITLE
Make dependencies less restrictive

### DIFF
--- a/lib/popular_stream.rb
+++ b/lib/popular_stream.rb
@@ -1,3 +1,4 @@
+require 'time'
 require "popular_stream/version"
 
 # Most of this was taken from:

--- a/popular_stream.gemspec
+++ b/popular_stream.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '~> 2.1'
-  spec.add_dependency "redis", "~> 3.1.0"
+  spec.add_dependency "redis", "~> 3.1"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.1.0"
+  spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "timecop", "~> 0.7.1"
   spec.add_development_dependency "fakeredis", "~> 0.5.0"
 end


### PR DESCRIPTION
Can't upgrade to latest version of redis with dependency locked to 3.1.x versions.
