### PR TITLE
Allow setting redis connection with a block

### DIFF
--- a/lib/popular_stream.rb
+++ b/lib/popular_stream.rb
@@ -12,10 +12,22 @@ class PopularStream
   HALF_LIFE = 1 * DAY
 
   class << self
-    attr_accessor :redis
+    def redis=(connection)
+      @redis = connection
+    end
+    
+    # Set the connection with a block. The block will be called at runtime to get the redis connection.
+    def set_redis(&block)
+      @redis = block
+    end
 
     def redis
       @redis ||= Redis.new(url: ENV['REDIS_URL'])
+      if @redis.is_a?(Proc)
+        @redis.call
+      else
+        @redis
+      end
     end
   end
 

--- a/popular_stream.gemspec
+++ b/popular_stream.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '~> 2.1'
-  spec.add_dependency "redis", "~> 3.1"
+  spec.required_ruby_version = '>= 2.1'
+  spec.add_dependency "redis"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/lib/popular_stream_spec.rb
+++ b/spec/lib/popular_stream_spec.rb
@@ -13,8 +13,14 @@ RSpec.describe PopularStream do
   describe ".redis" do
     let(:redis) { double }
 
-    it "is possible to set a redis instace" do
-      expect { PopularStream.redis = redis }.not_to raise_error
+    it "is possible to set a redis instance" do
+      PopularStream.redis = redis
+      expect(PopularStream.redis).to eq redis
+    end
+    
+    it "can set the redis instance with a block" do
+      PopularStream.set_redis{ redis }
+      expect(PopularStream.redis).to eq redis
     end
   end
 


### PR DESCRIPTION
This allows setting the redis connection with a block so if the connection changes (like when new processes are forked in a forking web server like puma or unicorn on restart), the redis connection can pick up the new value.